### PR TITLE
Switch from BeautifulSoup to html5-parser

### DIFF
--- a/Document.py
+++ b/Document.py
@@ -1,6 +1,15 @@
 import os
 import html
-from bs4 import BeautifulSoup
+import html5_parser
+from lxml import etree
+from lxml.cssselect import CSSSelector
+
+SELECTOR_FIRST_PARAGRAPH = CSSSelector('div[class=body] > div[class=section] > p:first-of-type')
+
+
+def node_to_text(node):
+    return ''.join(node.itertext())
+
 
 class Document:
     '''Return indexing data from an html document.'''
@@ -10,8 +19,11 @@ class Document:
         self._html_document_path = html_document_path
 
         # Soups
-        self._html_document = BeautifulSoup(html_document_path, "html.parser")
-        self._html_main_column = self._html_document.select('div[class="main-column"]')[0]
+        text = html_document_path.read()
+
+        capsule = html5_parser.html_parser.parse(text, maybe_xhtml=True)
+        self._html_document = etree.adopt_external_document(capsule).getroot()
+        self._html_main_column = self._html_document.find('.//div[@class="main-column"]')
 
         # Properties
         self.slug     = self.get_url_slug()
@@ -30,57 +42,57 @@ class Document:
 
     def get_page_title(self):
         '''Return the title of the page.'''
-        page_title = self._html_document.title.contents[0].__str__().strip()
+        page_title = self._html_document.find('.//title').text.strip()
         return page_title
 
     def get_page_headings(self):
         '''Return all heading tags (<h1>, <h2>, ..., <h6>) and their contents.'''
         all_headings = []
         # <h4>, <h5>, and <h6> seem to be used too granularly (if at all) to be used for heading search.
-        heading_types = ["h1", "h2", "h3"]#, "h4", "h5", "h6"]
-        for heading_type in heading_types:
-            headings = self._html_main_column.select(heading_type)
-            for heading in headings:
-                heading = heading.contents[0].__str__()
-                if heading[:1] == "<":
-                    # Remove headings that have internal tags. This only happens h4 and below from my observations.
-                    pass
-                else:
-                    all_headings.append(heading)
+        for heading in self._html_main_column.iter('h1', 'h2', 'h3'):
+            heading = node_to_text(heading)
+            if not heading:
+                continue
+
+            if heading[:1] == "<":
+                # Remove headings that have internal tags. This only happens h4 and below from my observations.
+                pass
+            else:
+                all_headings.append(heading)
         return all_headings
 
     def get_page_text(self):
         '''Return the text inside the <body> tag.'''
-        page_text = self._html_main_column.select('div[class=body]')[0].get_text()
+        page_text = node_to_text(self._html_main_column.find('.//div[@class="body"]'))
         #return page_text.replace('\n', ' ').replace('\r', '')
-        return ' '.join(page_text.split()).__str__()
+        return ' '.join(page_text.split())
 
     def get_page_preview(self):
         '''Return a summary of the page.'''
         page_preview = ""
         def set_to_meta_description():
             '''Set preview to the page's meta description.'''
-            return self._html_document.select("meta[type='description']")[0]
+            return node_to_text(self._html_document.find('.//meta[@name="description"]'))
         def set_to_first_paragraph():
             '''Set preview to the first descriptive paragraph on the page.'''
-            first_p_tag = self._html_main_column.select('div[class=body] > div[class=section] > p:first-of-type')[0]
-            return first_p_tag
+            nodes = SELECTOR_FIRST_PARAGRAPH(self._html_main_column)
+            if not nodes:
+                return ''
+
+            return node_to_text(nodes[0])
         try:
             page_preview = set_to_meta_description()
-        except:
-            try:
-                page_preview = set_to_first_paragraph()
-            except:
-                pass
+        except AttributeError:
+            page_preview = set_to_first_paragraph()
         return page_preview.replace('\n', ' ').replace('\r', ' ')
 
     def get_page_tags(self):
         '''Return the tags for the page.'''
-        page_tags = []
-        meta_keywords = self._html_document.find('meta', attrs={'name': 'keywords'})
-        if meta_keywords != None:
-            page_tags.extend(meta_keywords.attrs['content'].split(', '))
-        return page_tags
+        meta_keywords = self._html_document.find('.//meta[@name="keywords"]')
+        if meta_keywords is not None:
+            return meta_keywords.get('content')
+        else:
+            return ''
 
     def export(self):
         '''Generate the manifest dictionary for an html page.'''

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ import json
 from Index import Index
 from docopt import docopt
 
-PROJECT_DIR = '/Users/nick/VirtualEnvProjects/mut-index/'
+PROJECT_DIR = './'
 
 ## Server Manual
 # mut-index --url http://docs.mongodb.com/ manual-master /Users/nick/VirtualEnvProjects/mut-index/html_files


### PR DESCRIPTION
Not exhaustively tested, so take as sort of a starting point for testing.

Dependencies: lxml, html5-parser, and cssselect

I left a bunch of stuff as XPath selectors rather than CSS expressions because I'm feeling lazy and didn't find out that I could use the latter until after I finished, but there's an argument to be made that we should only use CSS expressions.